### PR TITLE
[HOPSWORKS-698] add kafka python documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,8 @@ Build the documentation
 Contribute
 ----------
 
-- Issue Tracker: github.com/hopshadoop/$project/issues
-- Source Code: github.com/hopshadoop/
+- Issue Tracker: github.com/logicalclocks/$project/issues
+- Source Code: github.com/logicalclocks/
 
 Support
 -------

--- a/docs/user_guide/hopsworks/kafka.rst
+++ b/docs/user_guide/hopsworks/kafka.rst
@@ -7,8 +7,8 @@ Hopsworks provides by default the `HopsUtil`_ and `hops-util-py`_ libraries whic
 
 The following sections demonstrate different ways for writing Kafka applications on Hopsworks:
 
-- Using the hopsworks **Kafka service** to setup Kafka topics in the cluster.
-- Using the hopsworks **jobs service** to submit jobs that produce/consume to/from Kafka.
+- Using the **Kafka service** on Hopsworks to setup Kafka topics in the cluster.
+- Using the **Jobs service** on Hopsworks to submit jobs that produce/consume to/from Kafka.
 - Using **Jupyter notebooks** on Hopsworks for producing/consuming to/from Kafka.
 
 Our service is tightly coupled with our project-based model so only members of a project can use a specific Kafka topic, unless specified otherwise. The Kafka service on Hops is multi-tenant, allowing users to share topics between projects as desired.
@@ -40,7 +40,7 @@ You can download and compile a sample Spark streaming by following these steps:
 
 **Create a Kafka topic and schema**
 
-The next step is to create a Kafka topic that the sample spark streaming application will produce to and consume from. To create a topic, we use the Kafka service available in the Hopsworks UI.
+The next step is to create a Kafka topic that the sample spark streaming application will produce to and consume from. To create a topic, we use the Kafka service available in Hopsworks.
 
 * Step 1: From the project box on the landing page, select a project
 * Step 2: Click on the `Kafka` tab and the topics page will appear
@@ -106,7 +106,7 @@ name of the project you would like to share with.
     Kafka main page
 
 You can also fine grain access to Kafka topics by adding ACLs easily
-through our UI. Once you have created a Kafka topic, click on the
+through Hopsworks. Once you have created a Kafka topic, click on the
 ``Kafka`` service and then on the *Add new ACL* button.
 
 When creating a new ACL you are given the following options:
@@ -170,7 +170,7 @@ finally the third is the custom ACL we created before.
 
 * Step 1: Upload the jar file from `hops-examples/spark/target/` to a dataset. The jar is named: `hops-examples-spark-X.Y.Z-SNAPSHOT.jar`.
 
-* Step 2: Click on the `Jobs` tabs at project menu and follow the instructions from the **Jobs** section. Create a new job for the Producer. Select `Spark` as job type and specify the jar file that you just uploaded. The name of the main class is `io.hops.examples.spark.kafka.StreamingExample` and argument is `producer`. At the `Configure and create` tab, click on `Kafka` Services and select the Kafka topic you created at Step 4. Your job page should look like the following:
+* Step 2: Click on the `Jobs` tabs at project menu and follow the instructions from the **Jobs** section. Create a new job for the Producer. Select `Spark` as job type and specify the jar file that you just uploaded. The name of the main class is `io.hops.examples.spark.kafka.StructuredStreamingKafka` and argument is `producer`. At the `Configure and create` tab, click on `Kafka` Services and select the Kafka topic you created at Step 4. Your job page should look like the following:
 
 .. _kafka-producer.png: ../../_images/kafka-producer.png
 .. figure:: ../../imgs/kafka-producer.png

--- a/docs/user_guide/hopsworks/kafka.rst
+++ b/docs/user_guide/hopsworks/kafka.rst
@@ -2,13 +2,19 @@
 Apache Kafka
 ===========================
 
+Hopsworks provides Kafka-as-a-Service for streaming applications.
+Hopsworks provides by default the `HopsUtil`_ and `hops-util-py`_ libraries which make programming easier by abstracting away all the configuration boilerplate code such as Kafka endpoints, topics etc. Using these libraries, you can be up and running a simple Kafka on Hopsworks `in minutes`.
 
-Hopsworks provides Kafka-as-a-Service for streaming
-applications. In the following section we will guide you through
-creating a *Producer* job which produces messages to a Kafka topic and a
-simple *Consumer* job which consumes from the same topic. Our service
-is tightly coupled with our project-based model so only members of a
-project can use a specific Kafka topic, unless specified otherwise.
+The following sections demonstrate different ways for writing Kafka applications on Hopsworks:
+
+- Using the hopsworks **Kafka service** to setup Kafka topics in the cluster.
+- Using the hopsworks **jobs service** to submit jobs that produce/consume to/from Kafka.
+- Using **Jupyter notebooks** on Hopsworks for producing/consuming to/from Kafka.
+
+Our service is tightly coupled with our project-based model so only members of a project can use a specific Kafka topic, unless specified otherwise. The Kafka service on Hops is multi-tenant, allowing users to share topics between projects as desired.
+
+Kafka Tour
+-----------------------
 
 If users prefer to be guided through the rest of the guide in Hopsworks, they can
 follow the `Kafka Tour` by selecting it from the available tours in the landing page.
@@ -22,27 +28,19 @@ follow the `Kafka Tour` by selecting it from the available tours in the landing 
     :figclass: align-center
 
 
+Example Spark Streaming Jobs with Kafka on Hopsworks
+-----------------------
 
-To begin with, Hopsworks provides by default the `HopsUtil`_ library which make programming easier
-by abstracting away all the configuration boilerplate code such
-as Kafka endpoints, topics etc. If users want to make changes to this library, they can use it with their jobs
-by doing the following:
+**Download and compile the example application**
 
-* Step 1: `git clone git@github.com:hopshadoop/hops-util.git` to clone
-  the library
-* Step 2: `cd hops-util/ && mvn package` to build it
+You can download and compile a sample Spark streaming by following these steps:
 
-Then you need to download and compile a sample Spark
-streaming application.
+* Step 1: run `git clone https://github.com/logicalclocks/hops-examples` to clone the example project
+* Step 2: run  `cd hops-examples/spark/ && mvn package` to build the example project
 
-* Step 1: `git clone
-  git@github.com:hopshadoop/hops-kafka-examples.git` to clone our
-  sample application
-* Step 2: `cd hops-kafka-examples/ && mvn package` to build the
-  project
+**Create a Kafka topic and schema**
 
-Next step is to create a Kafka topic at Hopsworks that our application
-will produce to and consume from.
+The next step is to create a Kafka topic that the sample spark streaming application will produce to and consume from. To create a topic, we use the Kafka service available in the Hopsworks UI.
 
 * Step 1: From the project box on the landing page, select a project
 * Step 2: Click on the `Kafka` tab and the topics page will appear
@@ -57,57 +55,39 @@ will produce to and consume from.
     Kafka topics & schemas
 
 * Step 3: First we need to create a schema for our topic, so click on
-  the `Schemas` tab and `New Avro Schema`. Copy the sample schema from
-  `here`_ and paste it in the `Content` box. Click on the `Validate`
+  the `Schemas` tab and `New Avro Schema`. Copy the sample schema from below and paste it into the `Content` box. Then click on the `Validate`
   button to validate the schema you provided and then `Create`.
+
+.. code-block:: JSON
+
+    {
+	"fields": [
+		{
+			"name": "timestamp",
+			"type": "string"
+		},
+		{
+			"name": "priority",
+			"type": "string"
+		},
+		{
+			"name": "logger",
+			"type": "string"
+		},
+		{
+			"name": "message",
+			"type": "string"
+		}
+	],
+	"name": "myrecord",
+	"type": "record"
+    }
+
 
 * Step 4: Click on `New Topic`, give a topic name, select the
   schema you created at Step 3 and press `Create`.
 
-* Step 5: Upload `hops-kafka-examples/spark/target/hops-spark-0.1.jar`
-  and `hops-util/target/hops-util-0.1.jar` to a dataset
-
-* Step 6: Click on the `Jobs` tabs at project menu and follow the
-  instructions from the **Jobs** section. Create a new job for the
-  Producer. Select `Spark` as job type and `hops-kafka-0.1.jar` as JAR
-  file. The name of the main class is
-  `io.hops.examples.spark.kafka.StreamingExample` and argument is
-  `producer`. At the `Configure and create` tab, click on `Kafka`
-  Services and select the Kafka topic you created at Step 4. Your job
-  page should look like the following
-
-.. _kafka-producer.png: ../../_images/kafka-producer.png
-.. figure:: ../../imgs/kafka-producer.png
-    :alt: Kafka producer job
-    :target: `kafka-producer.png`_
-    :align: center
-    :figclass: align-center
-
-    Kafka producer job
-
-* Step 7: We repeat the instructions on Step 6 for the Consumer
-  job. Type a different job name and as argument to the main class
-  pass `consumer /Projects/YOUR_PROJECT_NAME/Resources/Data`. The rest
-  remain the same as the Producer job.
-
-* Step 8: `Run` both jobs. While the consumer is running you can check
-  its execution log. Use the Dataset browser to navigate to the
-  directory `/Resources/Data-APPLICATION_ID/`. Right click on the file
-  `part-00000` and *Preview* the content.
-
-  A sample output would look like the following
-
-.. _kafka-sink.png: ../../_images/kafka-sink.png
-.. figure:: ../../imgs/kafka-sink.png
-    :alt: Kafka ouput
-    :target: `kafka-sink.png`_
-    :align: center
-    :figclass: align-center
-
-    Kafka output
-
-.. _here: https://github.com/hopshadoop/hops-kafka-examples/tree/master/spark
-.. _HopsUtil: https://github.com/hopshadoop/hops-util
+**Advanced Kafka Topic Creation**
 
 A Kafka topic by default will be accessible only to members of a
 specific project. In order to *share* the topic with another project
@@ -185,3 +165,81 @@ finally the third is the custom ACL we created before.
     :figclass: align-center
 
     Kafka topic details
+
+**Upload the compiled sample application and use it to create Spark jobs on Hopsworks**
+
+* Step 1: Upload the jar file from `hops-examples/spark/target/` to a dataset. The jar is named: `hops-examples-spark-X.Y.Z-SNAPSHOT.jar`.
+
+* Step 2: Click on the `Jobs` tabs at project menu and follow the instructions from the **Jobs** section. Create a new job for the Producer. Select `Spark` as job type and specify the jar file that you just uploaded. The name of the main class is `io.hops.examples.spark.kafka.StreamingExample` and argument is `producer`. At the `Configure and create` tab, click on `Kafka` Services and select the Kafka topic you created at Step 4. Your job page should look like the following:
+
+.. _kafka-producer.png: ../../_images/kafka-producer.png
+.. figure:: ../../imgs/kafka-producer.png
+    :alt: Kafka producer job
+    :target: `kafka-producer.png`_
+    :align: center
+    :figclass: align-center
+
+    Kafka producer job
+
+* Step 3: We repeat the instructions on Step 6 for the Consumer job. Type a different job name and as argument to the main class
+  pass `consumer /Projects/YOUR_PROJECT_NAME/Resources/Data`. The rest
+  remain the same as the Producer job.
+
+**Run the created producer/consumer jobs**
+`Run` both jobs. While the consumer is running you can check its execution log. Use the Dataset browser to navigate to the directory `/Resources/Data-APPLICATION_ID/`. Right click on the file `part-00000` and *Preview* the content.
+
+A sample output would look like the following:
+
+.. _kafka-sink.png: ../../_images/kafka-sink.png
+.. figure:: ../../imgs/kafka-sink.png
+    :alt: Kafka ouput
+    :target: `kafka-sink.png`_
+    :align: center
+    :figclass: align-center
+
+    Kafka output
+
+.. _here: https://github.com/hopshadoop/hops-kafka-examples/tree/master/spark
+.. _HopsUtil: https://github.com/hopshadoop/hops-util
+.. _hops-util-py: https://github.com/logicalclocks/hops-util-py
+
+Example Python Notebook with Kafka Producer and Consumer
+-----------------------
+
+You can find several example notebooks using kafka at hops_examples_.
+
+In this section we will demonstrate how you can use a jupyter notebook and python to produce/consume kafka messages. In this section it is assumed that you have already created a Kafka topic named "test" to produce/consume from and that you have enabled anaconda and installed the python package `kafka-confluent` in your project anaconda environment.
+
+**Start Jupyter**
+
+Start Jupyter by going to the Jupyter tab, selecting Spark(static or dynamic), filling in the system properties and pressing "Start".
+
+**Create the new notebook**
+
+Create a new notebook and paste the following
+
+.. code-block:: python
+
+    from hops import kafka
+    from hops import tls
+    from confluent_kafka import Producer, Consumer
+    TOPIC_NAME = "test"
+    config = kafka.get_kafka_default_config()
+    producer = Producer(config)
+    consumer = Consumer(config)
+    consumer.subscribe(["test"])
+    # wait a little while before executing the rest of the code (put it in a different Jupyter cell)
+    # so that the consumer get chance to subscribe (asynchronous call)
+    for i in range(0, 10):
+    producer.produce(TOPIC_NAME, "message {}".format(i), "key", callback=delivery_callback)
+    # Trigger the sending of all messages to the brokers, 10sec timeout
+    producer.flush(10)
+    for i in range(0, 10):
+    msg = consumer.poll(timeout=5.0)
+    if msg is not None:
+        print('Consumed Message: {} from topic: {}'.format(msg.value(), msg.topic()))
+    else:
+        print("Topic empty, timeout when trying to consume message")
+
+
+.. _hops_examples: https://github.com/logicalclocks/hops-examples

--- a/docs/user_guide/hopsworks/kafka.rst
+++ b/docs/user_guide/hopsworks/kafka.rst
@@ -208,7 +208,7 @@ Example Python Notebook with Kafka Producer and Consumer
 
 You can find several example notebooks using kafka at hops_examples_.
 
-In this section we will demonstrate how you can use a jupyter notebook and python to produce/consume kafka messages. In this section it is assumed that you have already created a Kafka topic named "test" to produce/consume from and that you have enabled anaconda and installed the python package `kafka-confluent` in your project anaconda environment.
+In this section we will demonstrate how you can use a jupyter notebook and python to produce/consume kafka messages. In this section it is assumed that you have already created a Kafka topic named "test" to produce/consume from and that you have enabled anaconda (which comes with some pre-installed packages, including the python package `kafka-confluent`) in your project.
 
 **Start Jupyter**
 

--- a/docs/user_guide/tensorflow/hops.rst
+++ b/docs/user_guide/tensorflow/hops.rst
@@ -8,59 +8,69 @@ hdfs
 -----------------------
 .. highlight:: python
 
-The ``hdfs`` module provides several ways of interacting with the Hops filesystem, where the Hopsworks project's data is stored. 
+The ``hdfs`` module provides several ways of interacting with the Hops filesystem, where the Hopsworks project's data is stored.
 
-**Pointing to a Dataset in Hopsworks**
+**Getting Project Information**
 
-
-In order to point to a dataset in Hopsworks the ``hdfs.project_path()`` function should be called. The function will return the HDFS path of your project, which is the view shown when clicking at ``Data Sets`` in Hopsworks. To point where your actual data resides in the project, you need to append the full path from there to your Dataset. 
-
-::   
+::
 
     from hops import hdfs
-    my_project_path = hdfs.project_path()
-    
-It is also possible to pass an argument corresponding to a different project for which you want to resolve the path to.    
+    project_user = hdfs.project_user() # returns: ProjectName__ProjectUserId
+    project_name = hdfs.project_name() # returns: ProjectName
+    project_path = hdfs.project_path() # returns: hdfs://ip:port/Projects/ProjectName/
 
-::   
 
-    from hops import hdfs
-    other_project_path = hdfs.project_path('deep-learning-101')    
-   
-    
-A simple use-case might be writing to a file in your project. Depending on whether you are using Python or PySpark kernel, you can follow one of two these different approaches in Jupyter.
+A common use-case for using the hdfs module to get project information is when you need to provide a path to your project-datasets for reading the dataset in your program, for example using a framework like Spark or Tensorflow. When providing a path to a dataset in your project, you'll typically write ``hdfs.project_path() + DATASET_NAME/...``. What's happening here is that ``hdfs.project_path()`` returns HDFS path to your project, this is the path you preview when you visit the ``Data Sets`` view in the Hopsworks UI. To get the full HDFS path to the dataset, the dataset name is appended to the project path.
 
-**Logging in the Python kernel**
+By default, ``hdfs.project_path()`` returns the path to the project that you are using while running the code. However, if you want to get the HDFS path to another project, you can pass an argument to the function with the project name:
 
-::   
+::
 
     from hops import hdfs
+    other_project_path = hdfs.project_path('deep-learning-101') #returns hdfs://ip:port/Projects/deep-learning-101/
+
+
+The practice of passing an argument to  ``hdfs.project_path()`` is commonly used when another project have shared a dataset with your project and you want to read that dataset in your program.
+
+**Read/Write From/To HDFS**
+
+To read and write from/to HDFS *without* using a framework like Spark or Tensorflow, you can use the hops utility functions ``load(hdfs_path)`` and ``dump(data, hdfs_path)`` in the hops utility library.
+::
+
+    from hops import hdfs
+    logs_README = hdfs.load("Logs/README.md") #reads a file in HDFS as raw bytes
+    print("logs README: {}".format(logs_README.decode("utf-8"))) # decodes the bytes into a string and prints it
+    hdfs.dump("test", "Logs/README_dump_test.md") # writes the string 'test' to hdfs://ip:port/Projects/ProjectName/Logs/README_dump_test_md
+
+    # alternative method for writing/reading to HDFS is to get the filesystem handle from the hops library and use it directly:
+
     fs_handle = hdfs.get_fs()
-    
     # Write to file in Hopsworks Resources dataset
     logfile = hdfs.project_path() + 'Resources/file.txt'
     fd = fs_handle.open_file(logfile, flags='w')
     fd.write('Hello Hopsworks')
-    fd.close()    
-    
-**Logging in the PySpark kernel**
-    
-When using the PySpark kernel you have to specify a wrapper function that you want to run on the executors. This wrapper function must be executed using the ``experiment`` module. To write log entries, the ``hdfs.log(string)`` method is used. It will write the string to a specific logfile for each experiment. The logfiles are stored in ``/Logs/TensorFlow/{appId}/{runId}/{hyperparameter}``. Keep in mind that this is a separate log from the one shown in the Spark UI in Hopsworks, which is simply the *stdout* and *stderr* of the running job.
+    fd.close()
+
+Note that, in the code snippet above, when we provide the hdfs-paths to ``hdfs.load()`` and ``hdfs.dump()`` we only provide the relative paths from the project root directory, not the full HDFS paths. When using the `hops hdfs` module, you can choose either to supply the full path or the relative path. If you provide only the relative path, the library will try to expand the path to its full path before executing the operation. This is just to make the library more user-friendly so that you don't always have to write the full HDFS path. Remember though, when you provide HDFS paths to frameworks like Spark or Tensorflow, you always need to provide the full path, e.g: ``hdfs.project_path() + relative_path``.
+
+**Logging using Hops Experiments**
+
+When using the PySpark kernel and Hops experiments you have to specify a wrapper function that you want to run on the executors. This wrapper function must be executed using the ``experiment`` module. To write log entries, the ``hdfs.log(string)`` method is used. It will write the string to a specific logfile for each experiment. The logfiles are stored in ``/Logs/TensorFlow/{appId}/{runId}/{hyperparameter}``. Keep in mind that this is a separate log from the one shown in the Spark UI in Hopsworks, which is simply the *stdout* and *stderr* of the running job.
 
 ::
-    
+
     def wrapper():
         from hops import hdfs
         hdfs.log('Hello Hopsworks')
-        
+
     from hops import experiment
     experiment.launch(spark, wrapper)
-    
-**Accessing datasets in Python or PySpark kernels**
+
+**Copying Datasets From/To HDFS**
 
 If you are using a framework such as TensorFlow you can read data directly from your project, since TensorFlow supports the HDFS filesystem and therefore HopsFS.
 
-This section is directed towards users that may want to use other frameworks such as *PyTorch* or *Theano* that do not support directly reading from HDFS. In this case the solution is to download the datasets to the executor running your code and then feed it in your program.
+This section is directed towards users that may want to use other frameworks than Tensorflow/Spark, such as *PyTorch* or *Theano*, that do not support directly reading from HDFS. In this case the solution is to download the datasets to the executor running your code and then feed it in your program.
 In order to easily copy datasets to and from your executor's working space and your Hopsworks project, the ``hdfs.copy_from_project`` and ``hdfs.copy_to_project`` functions should be used.
 
 ::
@@ -69,15 +79,17 @@ In order to easily copy datasets to and from your executor's working space and y
 
     # When using the Python Kernel
     # This code will copy the file mydata.json in the Resources dataset and place it in the root of your PDIR directory
+    # and name it local_file_name
     from hops import hdfs
-    hdfs.copy_from_project('Resources/mydata.json', '')
+    hdfs.copy_to_local('Resources/mydata.json', local_file_name)
 
     # When using the PySpark Kernel
     # This code will copy the file mydata.json in the Resources dataset and place it in the current working directory
+    # and name it local_file_name
     # Important! This is not persistently stored and will be removed when the executor is killed (job is complete or timeout)
     def wrapper():
         from hops import hdfs
-        hdfs.copy_from_project('Resources/mydata.json', '')
+        hdfs.copy_to_local('Resources/mydata.json', local_file_name)
 
 
     # Launch using experiment
@@ -90,13 +102,13 @@ In order to easily copy datasets to and from your executor's working space and y
     # When using the Python Kernel
     # This code will copy the file mydata.json located in your PDIR directory and place it in the Resources dataset of your Hopsworks project
     from hops import hdfs
-    hdfs.copy_to_project('mydata.json', 'Resources/')
+    hdfs.copy_to_hdfs('mydata.json', 'Resources/')
 
     # When using the PySpark Kernel
     # This code will copy the file mydata.json in your working directory and place it in the Resources dataset
     def wrapper():
         from hops import hdfs
-        hdfs.copy_to_project('mydata.json', 'Resources/')
+        hdfs.copy_to_hdfs('mydata.json', 'Resources/')
 
 
     # Launch using experiment
@@ -116,27 +128,27 @@ The ``experiment`` module is used for running one or more Parallel TensorFlow ex
     # A standalone job
     from hops import experiment
     root_tensorboard_logdir = experiment.launch(spark, single_experiments_wrapper)
-    
+
     ...............................................................................................
-    
+
     def multiple_experiments_wrapper(lr, dropout):
         # Wrapper function for arbitrarily many experiments
-        
+
     # Running two experiments
     args_dict = {'lr': [0.1, 0.3], 'dropout': [0.4, 0.7]}
-    
+
     # This code will run two jobs
     # job1: lr=0.1 and dropout=0.4
     # job2: lr=0.3 and dropout=0.7
-    
+
     from hops import experiment
     root_tensorboard_logdir = experiment.launch(spark, multiple_experiments_wrapper, args_dict)
-    
+
     ...............................................................................................
-    
+
     def grid_experiments_wrapper(lr, dropout):
         # Wrapper function for arbitrarily many experiments
-        
+
     # Running a grid of hyperparameter experiments
     args_dict = {'lr': [0.1, 0.3], 'dropout': [0.4, 0.7]}
 
@@ -145,28 +157,28 @@ The ``experiment`` module is used for running one or more Parallel TensorFlow ex
     # job2: lr=0.1 and dropout=0.7
     # job3: lr=0.3 and dropout=0.4
     # job4: lr=0.3 and dropout=0.7
-    
+
     from hops import experiment
 
     root_tensorboard_logdir = experiment.grid_search(spark, grid_experiments_wrapper, args_dict, direction='max')
-    
+
     ...............................................................................................
-    
+
     def evolutionary_experiments_wrapper(lr, dropout):
         # Wrapper function for arbitrarily many experiments
         metric = mycode.evaluate(lr, dropout)
         return metric
-        
+
     # Running a grid of hyperparameter experiments
     search_dict = {'lr': [0.1, 0.3], 'dropout': [0.4, 0.7]}
-    
+
     from hops import experiment
     root_tensorboard_logdir = experiment.evolutionary_search(spark, evolutionary_experiments_wrapper, search_dict, direction='max')
-    
-    
+
+
 tensorboard
 ------------------------------
-Hops supports TensorBoard for all TensorFlow modes (Parallel experiments, TensorFlowOnSpark and Horovod). 
+Hops supports TensorBoard for all TensorFlow modes (Parallel experiments, TensorFlowOnSpark and Horovod).
 When the ``experiment.launch`` function is invoked, a TensorBoard server will be started and available for each job. The *tensorboard* module provides a *logdir* method to get the log directory for summaries and checkpoints that are to be written to the TensorBoard. After each job is finished, the contents of the log directory will be placed in your Hopsworks project, under ``/Logs/TensorFlow/{appId}/{runId}/{hyperparameter}``. The directory name will correspond to the values of the hyperparameters for that particular job. The log directory could therefore be used to also write the final model or any other files that should be made available after execution is finished. Alternatively you can of course also write the model to any directory in your Hopsworks project.
 
 The *launch* function in *experiment* will return the directory in HopsFS, where each log directory is stored after execution is finished. The *visualize* method in *tensorboard* takes this path as an argument, and will start a new TensorBoard containing all the log directories of the execution, which will provide an easy way to identify the best model. Using this method, it is also possible to visualize old runs by simply supplying the path to this log directory from old runs.
@@ -184,7 +196,7 @@ The *launch* function in *experiment* will return the directory in HopsFS, where
 
     # Get the non-interactive debugger endpoint of the TensorBoard
     debugger_endpoint = tensorboard.non_interactive_debugger()
-    
+
     # Launching your training and visualizing everything in the same TensorBoard
     from hops import tensorboard
     import hops import experiment
@@ -229,3 +241,73 @@ The *util* module is used to expose certain helper methods.
     args_dict = {'learning_rate': [0.001, 0.0005, 0.0001], 'dropout': [0.45, 0.7]}
     args_dict_grid = util.grid_params(args_dict)
 
+
+kafka
+-----------------------
+The *kafka* module is used for creating Kafka consumers/producers to communicate with a Kafka cluster running in Hops using secure SSL/TLS communication.
+
+For using kafka with the hops library you should already have created your kafka topics through the Hopsworks UI (see instructions here: hopskafka_.)
+
+.. _hopskafka: ../hopsworks/kafka.html
+**Defining the Kafka configuration**
+
+The module provides utility methods for setting up secure communication using Kafka producers and consumers running inside a Hopsworks cluster. You can use this utility methods in combination with any python kafka client. In the examples below we will show how you can use ``confluent-kafka-python`` and ``Spark`` clients for creating Kafka producers and consumers with minimal amount of code.
+
+::
+
+    from hops import kafka
+    from hops import tls
+
+    # the default configuration is designed for use with confluent-kafka-python
+    config = kafka.get_kafka_default_config()
+
+    # if you want to use another library than confluent-kafka-python or configure the default config
+    # you can call the individual utility functions and set the configuration as required
+    config = {
+        "bootstrap.servers": kafka.get_broker_endpoints(),
+        "security.protocol": kafka.get_security_protocol(),
+        "ssl.ca.location": tls.get_ca_chain_location(),
+        "ssl.certificate.location": tls.get_client_certificate_location(),
+        "ssl.key.location": tls.get_client_key_location(),
+        "group.id": "something"
+    }
+
+
+**Creating Kafka Producer or Consumer**
+
+Once the configuration is set up, you can use the Kafka libraries of your choice. Below is an example of creating a producer and a consumer with the ``kafka-confluent-python`` library, and for creating a consumer using ``pyspark`` streaming.
+::
+
+    from hops import kafka
+    from hops import tls
+    from confluent_kafka import Producer, Consumer
+
+    # -- Using confluent-kafka-python --
+    producer = Producer(config)
+    consumer = Consumer(config)
+
+    # -- Using pyspark --
+    df = spark \
+    .format("kafka") \
+    .option("kafka.bootstrap.servers", kafka.get_broker_endpoints()) \
+    .option("kafka.ssl.truststore.location", tls.get_trust_store()) \
+    .option("kafka.ssl.truststore.password", tls.get_key_store_pwd()) \
+    .option("kafka.ssl.keystore.location", tls.get_key_store()) \
+    .option("kafka.ssl.keystore.password", tls.get_key_store_pwd()) \
+    .option("kafka.ssl.key.password", tls.get_trust_store_pwd()) \
+    .option("subscribe", TOPIC_NAME) \
+    .load()
+
+
+Once you have created the consumers/producers with the right configuration, you can use the API of your choice to write/read to the Kafka cluster in Hops. Some examples are given here: hops_examples_, and you can find more examples on the documentation pages of respective framework (e.g. ``kafka-confluent-python`` or  ``Spark``)
+
+.. _hops_examples: https://github.com/logicalclocks/hops-examples
+
+**Getting the schema for a topic**
+
+After you have created a kafka consumer or producer, you might need the schema for the topic you are going to consume/produce to, you can get it from the hops utility library by using the function `get_schema()`.
+
+::
+
+    from hops import kafka
+    kafka.get_schema(TOPIC_NAME)

--- a/docs/user_guide/tensorflow/hops.rst
+++ b/docs/user_guide/tensorflow/hops.rst
@@ -1,7 +1,7 @@
 Hops Python library
 =======================
 
-**Hops library** provides a set of modules that make it simple to run TensorFlow code with Jupyter on Hops.
+**Hops library** provides a set of modules that make it simple to run TensorFlow code with Jupyter on Hops. The API documentation is available here: API-docs_.
 
 
 hdfs
@@ -20,7 +20,7 @@ The ``hdfs`` module provides several ways of interacting with the Hops filesyste
     project_path = hdfs.project_path() # returns: hdfs://ip:port/Projects/ProjectName/
 
 
-A common use-case for using the hdfs module to get project information is when you need to provide a path to your project-datasets for reading the dataset in your program, for example using a framework like Spark or Tensorflow. When providing a path to a dataset in your project, you'll typically write ``hdfs.project_path() + DATASET_NAME/...``. What's happening here is that ``hdfs.project_path()`` returns HDFS path to your project, this is the path you preview when you visit the ``Data Sets`` view in the Hopsworks UI. To get the full HDFS path to the dataset, the dataset name is appended to the project path.
+A common use-case for using the hdfs module to get project information is when you need to provide a path to your project-datasets for reading the dataset in your program, for example using a framework like Spark or Tensorflow. When providing a path to a dataset in your project, you'll typically write ``hdfs.project_path() + DATASET_NAME/...``. What's happening here is that ``hdfs.project_path()`` returns the HDFS path to your project, this is the path you preview when you visit the ``Data Sets`` view in Hopsworks. To get the full HDFS path to the dataset, the dataset name is appended to the project path.
 
 By default, ``hdfs.project_path()`` returns the path to the project that you are using while running the code. However, if you want to get the HDFS path to another project, you can pass an argument to the function with the project name:
 
@@ -30,7 +30,7 @@ By default, ``hdfs.project_path()`` returns the path to the project that you are
     other_project_path = hdfs.project_path('deep-learning-101') #returns hdfs://ip:port/Projects/deep-learning-101/
 
 
-The practice of passing an argument to  ``hdfs.project_path()`` is commonly used when another project have shared a dataset with your project and you want to read that dataset in your program.
+The practice of passing an argument to  ``hdfs.project_path()`` is commonly used when another project has shared a dataset with your project and you want to read that dataset in your program.
 
 **Read/Write From/To HDFS**
 
@@ -178,7 +178,7 @@ The ``experiment`` module is used for running one or more Parallel TensorFlow ex
 
 tensorboard
 ------------------------------
-Hops supports TensorBoard for all TensorFlow modes (Parallel experiments, TensorFlowOnSpark and Horovod).
+Hops supports TensorBoard for all TensorFlow modes (Experiments, Parallel experiments, and Distributed training).
 When the ``experiment.launch`` function is invoked, a TensorBoard server will be started and available for each job. The *tensorboard* module provides a *logdir* method to get the log directory for summaries and checkpoints that are to be written to the TensorBoard. After each job is finished, the contents of the log directory will be placed in your Hopsworks project, under ``/Logs/TensorFlow/{appId}/{runId}/{hyperparameter}``. The directory name will correspond to the values of the hyperparameters for that particular job. The log directory could therefore be used to also write the final model or any other files that should be made available after execution is finished. Alternatively you can of course also write the model to any directory in your Hopsworks project.
 
 The *launch* function in *experiment* will return the directory in HopsFS, where each log directory is stored after execution is finished. The *visualize* method in *tensorboard* takes this path as an argument, and will start a new TensorBoard containing all the log directories of the execution, which will provide an easy way to identify the best model. Using this method, it is also possible to visualize old runs by simply supplying the path to this log directory from old runs.
@@ -246,7 +246,7 @@ kafka
 -----------------------
 The *kafka* module is used for creating Kafka consumers/producers to communicate with a Kafka cluster running in Hops using secure SSL/TLS communication.
 
-For using kafka with the hops library you should already have created your kafka topics through the Hopsworks UI (see instructions here: hopskafka_.)
+For using kafka with the hops library you should already have created your kafka topics through Hopsworks (see instructions here: hopskafka_.)
 
 .. _hopskafka: ../hopsworks/kafka.html
 **Defining the Kafka configuration**
@@ -302,6 +302,7 @@ Once the configuration is set up, you can use the Kafka libraries of your choice
 Once you have created the consumers/producers with the right configuration, you can use the API of your choice to write/read to the Kafka cluster in Hops. Some examples are given here: hops_examples_, and you can find more examples on the documentation pages of respective framework (e.g. ``kafka-confluent-python`` or  ``Spark``)
 
 .. _hops_examples: https://github.com/logicalclocks/hops-examples
+.. _API-docs: http://hops-py.logicalclocks.com/
 
 **Getting the schema for a topic**
 


### PR DESCRIPTION
In hops 0.6.0, kafka will be supported in hops-util-py, this PR adds documentation for that.

Wait for https://github.com/logicalclocks/hops-util-py/pull/13 to be merged